### PR TITLE
fix the permissions given to the key so www-data can read it

### DIFF
--- a/src/items/ItemCloudFrontReplacement.php
+++ b/src/items/ItemCloudFrontReplacement.php
@@ -146,7 +146,7 @@ class ItemCloudFrontReplacement extends ConfigurableService implements ItemAsset
                 $response = $s3Adapter->read($this->getOption(self::OPTION_S3_KEYFILE));
                 if ($response !== false) {
                     file_put_contents($this->getOption(self::OPTION_LOCAL_KEYFILE), $response['contents']);
-                    chmod($this->getOption(self::OPTION_LOCAL_KEYFILE), 700);
+                    chmod($this->getOption(self::OPTION_LOCAL_KEYFILE), 0600);
                 } else {
                     throw new \common_Exception('Unable to retrieve key file from s3 : ' . $this->getOption(self::OPTION_LOCAL_KEYFILE));
                 }


### PR DESCRIPTION
correct use of the chmod method : http://php.net/manual/en/function.chmod.php
to reproduce put bucket to camille's one prefix to antoine/key and s3File to pk-test.pem, (it is not a valid key but still reproduce the "can't open" issue)