### PR TITLE
Method hDel implementation for DynamoDB driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"GPL-2.0-only"
 	],
 	"require" : {
-		"php" : ">=5.3.10",
+		"php" : ">=5.4",
 		"league/flysystem-aws-s3-v3": "1.0.25",
 		"aws/aws-sdk-php": "^3.0.0"
 	},


### PR DESCRIPTION
Work is done under [CGF-89](https://oat-sa.atlassian.net/browse/CGF-89)

It allows the use of `hDel` method, that introduced in `common_persistence_AdvKvDriver`. 

### How to test

Need to have installed DynamoDB locally and configured TAO to use it, that it is a bit outside from this pull request to be honest.
 
After need to create any tables for tests, for example, `anytable` by the following command.
```
aws dynamodb --endpoint-url http://127.0.0.1:8000 \
	create-table --table-name anytable \
	--attribute-definitions AttributeName=key,AttributeType=S \
	--key-schema AttributeName=key,KeyType=HASH \
	--provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5
```

In test class `generis/test/unit/common/persistence/AdvKeyValuePersistenceTest.php` adjust method `setUp` by the following code:

```php
        $this->largeValuePersistence = (new AwsDynamoDbDriver())->connect('dynamodb', [
            AdvKeyValuePersistence::MAX_VALUE_SIZE => 100,
            AwsDynamoClientFactory::OPTION_TABLE => 'anytable',
            AwsDynamoClientFactory::OPTION_CLIENT => [
                'region' => 'local',
                'scheme' => 'http',
                'version' => 'latest',
                'credentials' => [
                    'key' => 'myk',
                    'secret' => 'mys',
                ]
            ]
        ]);
```

After run `testHDelSmallValue` and `testHDelLargeValue` methods to check if hDel works as expected.