### PR TITLE
Signature compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"GPL-2.0-only"
 	],
 	"require" : {
-		"php" : ">=5.4",
+		"php" : ">=7.2",
 		"league/flysystem-aws-s3-v3": "1.0.25",
 		"aws/aws-sdk-php": "^3.0.0"
 	},

--- a/src/awsDynamoDb/AwsDynamoDbDriver.php
+++ b/src/awsDynamoDb/AwsDynamoDbDriver.php
@@ -459,7 +459,7 @@ class AwsDynamoDbDriver implements \common_persistence_AdvKvDriver
      *
      * @return bool Returns true if deletting was successful and false if any issue happened or entry was not found
      */
-    public function hDel($key, $field)
+    public function hDel($key, $field): bool
     {
         \common_Logger::t('Call of ' . __METHOD__);
 


### PR DESCRIPTION
Work for [CGF-89](https://oat-sa.atlassian.net/browse/CGF-89)

- Added missed returned type for methods signature to be the same as in the interface.
- Bump PHP version up to 7.2 as an interface use features from PHP 7.