### PR TITLE
Add a service for moving assets to CloudFront

### DIFF
--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -124,7 +124,7 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
         if ($this->hasOption(self::OPTION_EXCLUDE_PATTERNS)) {
             return $this->checkPatterns($src, $this->getOption(self::OPTION_EXCLUDE_PATTERNS));
         }
-        return $this->checkPatterns($src, self::EXCLUDE_PATTERNS);
+        return $this->checkPatterns($src, self::DEFAULT_EXCLUDE_PATTERNS);
     }
 
     /**

--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -96,7 +96,9 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
      */
     private function getFilenameFormPacket(PackedAsset $packetAsset): string
     {
-        return $packetAsset->getMediaAsset()->getMediaSource()->getBaseName($packetAsset->getMediaAsset()->getMediaIdentifier());
+        $mediaAsset = $packetAsset->getMediaAsset();
+        $identifier = $mediaAsset->getMediaIdentifier();
+        return $mediaAsset->getMediaSource()->getBaseName($identifier);
     }
 
     /**
@@ -104,7 +106,9 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
      */
     private function getResourceFromPacket(PackedAsset $packetAsset)
     {
-        $fileStream = $packetAsset->getMediaAsset()->getMediaSource()->getFileStream($packetAsset->getMediaAsset()->getMediaIdentifier());
+        $mediaAsset = $packetAsset->getMediaAsset();
+        $identifier = $mediaAsset->getMediaIdentifier();
+        $fileStream = $mediaAsset->getMediaSource()->getFileStream($identifier);
         return $fileStream->detach();
     }
 

--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -128,11 +129,14 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
 
     /**
      * Check patterns
+     * @param string $src
+     * @param array $patterns
+     * @return bool
      */
-    private function checkPatterns(string $src, array $patterns) : bool
+    private function checkPatterns(string $src, array $patterns): bool
     {
-        foreach ($patterns as $pattern){
-            if(preg_match($pattern, $src) == 1) {
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $src) == 1) {
                 return true;
             }
         }
@@ -141,7 +145,7 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
 
     private function getAwsClient(): AwsClient
     {
-       return $this->getServiceLocator()->get('generis/awsClient');
+        return $this->getServiceLocator()->get('generis/awsClient');
     }
 
     private function getItemAssetsReplacement(): ItemAssetsReplacement

--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\awsTools\QtiItems;
+
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use League\Flysystem\Config;
+use oat\awsTools\AwsClient;
+use oat\awsTools\items\ItemCloudFrontReplacement;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiItem\model\compile\QtiAssetReplacer\QtiItemAssetReplacer;
+use oat\taoQtiItem\model\pack\QtiAssetPacker\PackedAsset;
+
+class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiItemAssetReplacer
+{
+    /**
+     * The host for the external source
+     */
+    const OPTION_HOST = 'host';
+
+    /**
+     * The prefix for the path
+     */
+    const OPTION_PREFIX = 'prefix';
+
+    public function shouldBeReplacedWithExternal(PackedAsset $packetAsset): bool
+    {
+        return !$this->isExcluded($this->getFilenameFormPacket($packetAsset));
+    }
+
+    public function replaceToExternalSource(PackedAsset $packetAsset, string $itemId): string
+    {
+        $filename = $this->getFilenameFormPacket($packetAsset);
+
+        $awsClient = $this->getAwsClient();
+        $s3Client = $awsClient->getS3Client();
+        $config = new Config();
+
+        $itemAssetReplacement = $this->getItemAssetsReplacement();
+
+        if (!($itemAssetReplacement instanceof ItemCloudFrontReplacement)) {
+            throw new \Exception('The ItemCloudFrontReplacement service should be configured properly for using CloudFront assets.');
+        }
+
+        $s3Adapter = new AwsS3Adapter(
+            $s3Client,
+            $itemAssetReplacement->getOption(ItemCloudFrontReplacement::OPTION_S3_BUCKET),
+            $this->getOption(self::OPTION_PREFIX)
+        );
+
+        $path = $this->buildPath($itemId);
+
+        $s3Adapter->writeStream($path . $filename, $this->getResourceFormPacket($packetAsset), $config);
+
+        return $this->getOption(self::OPTION_HOST) . DIRECTORY_SEPARATOR . $path . $filename;
+    }
+
+    private function buildPath(string $itemId): string
+    {
+        return 'items' . DIRECTORY_SEPARATOR . $itemId . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR ;
+    }
+
+    private function getFilenameFormPacket(PackedAsset $packetAsset): string
+    {
+        return $packetAsset->getMediaAsset()->getMediaSource()->getBaseName($packetAsset->getMediaAsset()->getMediaIdentifier());
+    }
+
+    private function getResourceFormPacket(PackedAsset $packetAsset)
+    {
+        $fileStream = $packetAsset->getMediaAsset()->getMediaSource()->getFileStream($packetAsset->getMediaAsset()->getMediaIdentifier());
+        return $fileStream->detach();
+    }
+
+    private function isExcluded(string $src): bool
+    {
+        return $this->checkPatterns($src, self::EXCLUDE_PATTERNS);
+    }
+
+    private function checkPatterns(string $src, array $patterns) : bool
+    {
+        foreach ($patterns as $pattern){
+            if(preg_match($pattern, $src) == 1){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getAwsClient(): AwsClient
+    {
+       return $this->getServiceLocator()->get('generis/awsClient');
+    }
+
+    private function getItemAssetsReplacement(): ItemAssetsReplacement
+    {
+        return $this->getServiceLocator()->get(ItemAssetsReplacement::SERVICE_ID);
+    }
+}

--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -54,7 +54,7 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
     /**
      * {@inheritDoc}
      *
-     * @throws \Exception
+     * @throws \common_Exception
      */
     public function replaceToExternalSource(PackedAsset $packetAsset, string $itemId): string
     {
@@ -67,7 +67,7 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
         $itemAssetReplacement = $this->getItemAssetsReplacement();
 
         if (!($itemAssetReplacement instanceof ItemCloudFrontReplacement)) {
-            throw new \Exception('The ItemCloudFrontReplacement service should be configured properly for using CloudFront assets.');
+            throw new \common_Exception('The ItemCloudFrontReplacement service should be configured properly for using CloudFront assets.');
         }
 
         $s3Adapter = new AwsS3Adapter(

--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\awsTools\QtiItems;
 
+use Aws\S3\S3Client;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
 use League\Flysystem\Config;
 use oat\awsTools\AwsClient;
@@ -70,7 +71,7 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
             throw new \common_Exception('The ItemCloudFrontReplacement service should be configured properly for using CloudFront assets.');
         }
 
-        $s3Adapter = new AwsS3Adapter(
+        $s3Adapter = $this->getAwsS3Adapter(
             $s3Client,
             $itemAssetReplacement->getOption(ItemCloudFrontReplacement::OPTION_S3_BUCKET),
             $this->getOption(self::OPTION_PREFIX)
@@ -142,5 +143,14 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
     private function getItemAssetsReplacement(): ItemAssetsReplacement
     {
         return $this->getServiceLocator()->get(ItemAssetsReplacement::SERVICE_ID);
+    }
+
+    protected function getAwsS3Adapter(S3Client $s3Client, string $bucket, string $prefix): AwsS3Adapter
+    {
+        return new AwsS3Adapter(
+            $s3Client,
+            $bucket,
+            $prefix
+        );
     }
 }

--- a/test/unit/QtiItemAssetCloudFrontReplacerTest.php
+++ b/test/unit/QtiItemAssetCloudFrontReplacerTest.php
@@ -176,16 +176,6 @@ class QtiItemAssetCloudFrontReplacerTest extends TestCase
             $this->resolver
         );
 
-        $this->assertArrayHasKey('stimulus-href', $packedAssets);
-        $this->assertInstanceOf(PackedAsset::class, $packedAssets['stimulus-href']);
-        $this->assertSame('xinclude', $packedAssets['stimulus-href']->getType());
-        $this->assertSame('stimulus-link', $packedAssets['stimulus-href']->getLink());
-        $this->assertSame('stimulus-link', $this->getFilenameWithoutPrefix($packedAssets['stimulus-href']->getReplacedBy()));
-
-        $this->assertArrayHasKey('image-src', $packedAssets);
-        $this->assertInstanceOf(PackedAsset::class, $packedAssets['image-src']);
-        $this->assertSame('img', $packedAssets['image-src']->getType());
-        $this->assertSame('image-link', $packedAssets['image-src']->getLink());
         $this->assertSame('host/items/i12345qwerty/assets/image-link', $packedAssets['image-src']->getReplacedBy());
     }
 

--- a/test/unit/QtiItemAssetCloudFrontReplacerTest.php
+++ b/test/unit/QtiItemAssetCloudFrontReplacerTest.php
@@ -177,18 +177,13 @@ class QtiItemAssetCloudFrontReplacerTest extends TestCase
         $this->assertInstanceOf(PackedAsset::class, $packedAssets['stimulus-href']);
         $this->assertSame('xinclude', $packedAssets['stimulus-href']->getType());
         $this->assertSame('stimulus-link', $packedAssets['stimulus-href']->getLink());
-        $this->assertSame($this->getReplacementName('stimulus-link'), $this->getFilenameWithoutPrefix($packedAssets['stimulus-href']->getReplacedBy()));
+        $this->assertSame('stimulus-link', $this->getFilenameWithoutPrefix($packedAssets['stimulus-href']->getReplacedBy()));
 
         $this->assertArrayHasKey('image-src', $packedAssets);
         $this->assertInstanceOf(PackedAsset::class, $packedAssets['image-src']);
         $this->assertSame('img', $packedAssets['image-src']->getType());
         $this->assertSame('image-link', $packedAssets['image-src']->getLink());
-        $this->assertSame($this->getReplacementName('host/items/i12345qwerty/assets/image-link'), $packedAssets['image-src']->getReplacedBy());
-    }
-
-    private function getReplacementName(string $string): string
-    {
-        return $string;
+        $this->assertSame('host/items/i12345qwerty/assets/image-link', $packedAssets['image-src']->getReplacedBy());
     }
 
     private function getFilenameWithoutPrefix(string $filename): string

--- a/test/unit/QtiItemAssetCloudFrontReplacerTest.php
+++ b/test/unit/QtiItemAssetCloudFrontReplacerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -107,7 +108,7 @@ class QtiItemAssetCloudFrontReplacerTest extends TestCase
            QtiItemCompilerAssetBlacklist::SERVICE_ID => $this->blackListService,
            LoggerService::SERVICE_ID => new NullLogger(),
            QtiItemAssetReplacer::SERVICE_ID => $replacer,
-       ]));
+        ]));
 
         $this->resolver = $this->createMock(ItemMediaResolver::class);
         $this->item = $this->createMock(Item::class);
@@ -147,10 +148,12 @@ class QtiItemAssetCloudFrontReplacerTest extends TestCase
                         [
                             'getFileInfo' => ['link' => 'image-link'],
                             'getBaseName' => 'image-link',
-                            'getFileStream' => $this->createConfiguredMock(Stream::class,
-                            [
+                            'getFileStream' => $this->createConfiguredMock(
+                                Stream::class,
+                                [
                                 'detach' => true
-                            ])
+                                ]
+                            )
                         ]
                     ),
                     'image-fixture'

--- a/test/unit/QtiItemAssetCloudFrontReplacerTest.php
+++ b/test/unit/QtiItemAssetCloudFrontReplacerTest.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\awsTools\test\unit;
+
+use Aws\S3\S3Client;
+use GuzzleHttp\Psr7\Stream;
+use League\Flysystem\AwsS3v3\AwsS3Adapter;
+use oat\awsTools\AwsClient;
+use oat\awsTools\items\ItemCloudFrontReplacement;
+use oat\awsTools\QtiItems\QtiItemAssetCloudFrontReplacer;
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\File;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\media\MediaAsset;
+use oat\tao\model\media\MediaBrowser;
+use oat\taoItems\model\media\ItemMediaResolver;
+use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoQtiItem\model\compile\QtiAssetCompiler\QtiItemAssetCompiler;
+use oat\taoQtiItem\model\compile\QtiAssetReplacer\QtiItemAssetReplacer;
+use oat\taoQtiItem\model\compile\QtiAssetReplacer\QtiItemNonReplacer;
+use oat\taoQtiItem\model\compile\QtiItemCompilerAssetBlacklist;
+use oat\taoQtiItem\model\pack\QtiAssetPacker\PackedAsset;
+use oat\taoQtiItem\model\qti\Img;
+use oat\taoQtiItem\model\qti\Item;
+use oat\taoQtiItem\model\qti\XInclude;
+use oat\taoQtiItem\test\unit\model\compile\mock\ElementMock;
+use oat\generis\test\TestCase;
+use Psr\Log\NullLogger;
+
+class QtiItemAssetCloudFrontReplacerTest extends TestCase
+{
+    /** @var QtiItemAssetCompiler */
+    private $subject;
+
+    /** @var QtiItemCompilerAssetBlacklist */
+    private $blackListService;
+
+    /** @var ItemMediaResolver */
+    private $resolver;
+
+    /** @var Item */
+    private $item;
+
+    /** @var Directory */
+    private $directory;
+
+    /**
+     * @var AwsClient
+     */
+    private $awsClient;
+
+    /**
+     * @var ItemAssetsReplacement
+     */
+    private $itemAssetsReplacement;
+
+    /**
+     * @var AwsS3Adapter
+     */
+    private $awsS3Adapter;
+
+    public function setUp(): void
+    {
+        $this->subject = new QtiItemAssetCompiler();
+
+        $this->blackListService = $this->createMock(QtiItemCompilerAssetBlacklist::class);
+        $this->awsClient = $this->createMock(AwsClient::class);
+        $this->itemAssetsReplacement = $this->createMock(ItemCloudFrontReplacement::class);
+        $this->itemAssetsReplacement->method('getOption')->willReturn('bucket_test');
+
+        $this->awsS3Adapter = $this->createMock(AwsS3Adapter::class);
+        $this->awsS3Adapter->method('writeStream')->willReturn(true);
+
+        $replacer = new TestQtiItemAssetCloudFrontReplacer([
+            QtiItemAssetCloudFrontReplacer::OPTION_PREFIX => 'prefix',
+            QtiItemAssetCloudFrontReplacer::OPTION_HOST => 'host'
+        ]);
+
+        $replacer->setAwsS3Adapter($this->awsS3Adapter);
+
+        $replacer->setServiceLocator($this->getServiceLocatorMock([
+            'generis/awsClient' => $this->awsClient,
+             ItemAssetsReplacement::SERVICE_ID => $this->itemAssetsReplacement
+        ]));
+
+        $this->subject->setServiceLocator($this->getServiceLocatorMock([
+           QtiItemCompilerAssetBlacklist::SERVICE_ID => $this->blackListService,
+           LoggerService::SERVICE_ID => new NullLogger(),
+           QtiItemAssetReplacer::SERVICE_ID => $replacer,
+       ]));
+
+        $this->resolver = $this->createMock(ItemMediaResolver::class);
+        $this->item = $this->createMock(Item::class);
+        $this->directory = $this->createMock(Directory::class);
+    }
+
+    public function testReplaceAssets()
+    {
+        $this->item
+            ->method('getComposingElements')
+            ->willReturn([
+            (new ElementMock())->setComposingElements([
+                $this->createConfiguredMock(XInclude::class, ['attr' => 'stimulus-href'])
+            ]),
+            (new ElementMock())->setComposingElements([
+                $this->createConfiguredMock(Img::class, ['attr' => 'image-src'])
+            ])
+        ]);
+        $this->item->method('getIdentifier')->willReturn('i12345qwerty');
+
+        $this->resolver->expects($this->exactly(2))
+            ->method('resolve')
+            ->willReturnOnConsecutiveCalls(
+                new MediaAsset(
+                    $this->createConfiguredMock(
+                        MediaBrowser::class,
+                        [
+                            'getFileInfo' => ['link' => 'stimulus-link'],
+                            'getBaseName' => 'stimulus-link'
+                        ]
+                    ),
+                    'stimulus-fixture'
+                ),
+                new MediaAsset(
+                    $this->createConfiguredMock(
+                        MediaBrowser::class,
+                        [
+                            'getFileInfo' => ['link' => 'image-link'],
+                            'getBaseName' => 'image-link',
+                            'getFileStream' => $this->createConfiguredMock(Stream::class,
+                            [
+                                'detach' => true
+                            ])
+                        ]
+                    ),
+                    'image-fixture'
+                )
+            );
+
+        $this->directory
+            ->method('getFile')
+            ->willReturn(
+                $this->createConfiguredMock(File::class, ['write' => true])
+            );
+
+        $this->blackListService->method('isBlacklisted')->willReturn(false);
+
+        $this->awsClient->method('getS3Client')->willReturn($this->createMock(S3Client::class));
+
+        $packedAssets = $this->subject->extractAndCopyAssetFiles(
+            $this->item,
+            $this->directory,
+            $this->resolver
+        );
+
+        $this->assertArrayHasKey('stimulus-href', $packedAssets);
+        $this->assertInstanceOf(PackedAsset::class, $packedAssets['stimulus-href']);
+        $this->assertSame('xinclude', $packedAssets['stimulus-href']->getType());
+        $this->assertSame('stimulus-link', $packedAssets['stimulus-href']->getLink());
+        $this->assertSame($this->getReplacementName('stimulus-link'), $this->getFilenameWithoutPrefix($packedAssets['stimulus-href']->getReplacedBy()));
+
+        $this->assertArrayHasKey('image-src', $packedAssets);
+        $this->assertInstanceOf(PackedAsset::class, $packedAssets['image-src']);
+        $this->assertSame('img', $packedAssets['image-src']->getType());
+        $this->assertSame('image-link', $packedAssets['image-src']->getLink());
+        $this->assertSame($this->getReplacementName('host/items/i12345qwerty/assets/image-link'), $packedAssets['image-src']->getReplacedBy());
+    }
+
+    private function getReplacementName(string $string): string
+    {
+        return $string;
+    }
+
+    private function getFilenameWithoutPrefix(string $filename): string
+    {
+        $delimiter = '_';
+        return substr($filename, strpos($filename, $delimiter) + 1);
+    }
+}
+
+class TestQtiItemAssetCloudFrontReplacer extends QtiItemAssetCloudFrontReplacer
+{
+    private $awsS3Adapter;
+
+    public function setAwsS3Adapter($mock)
+    {
+        $this->awsS3Adapter = $mock;
+    }
+
+    protected function getAwsS3Adapter(S3Client $s3Client, string $bucket, string $prefix): AwsS3Adapter
+    {
+        return $this->awsS3Adapter;
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-130

How to test:

1. Configure your instance for working with cloudfront based on this doc https://oat-sa.atlassian.net/wiki/spaces/DevOps/pages/125633576/Cloudfrontification
2. Register the QtiItemAssetCloudFrontReplacer service in the `config/taoQtiItem/ItemAssetReplacer.conf.php` with the next properties:
`return new \oat\awsTools\QtiItems\QtiItemAssetCloudFrontReplacer(array(
 'host' => '{cloudfron_host}',
 'prefix' => 'folder_prefix'
));`
3. Publish a delivery from a test with media assets.
4. Run the delivery

Note: For now we don't have credentials for cloundfront for testing locally.