### PR TITLE
feat: update dependencies for dbal3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"GPL-2.0-only"
 	],
 	"require" : {
-		"php" : ">=7.2",
+		"php" : ">=8.1",
 		"league/flysystem-aws-s3-v3": "^3.0.0",
 		"aws/aws-sdk-php": "^3.0.0"
 	},

--- a/src/awsDynamoDb/AwsDynamoClientFactory.php
+++ b/src/awsDynamoDb/AwsDynamoClientFactory.php
@@ -126,9 +126,9 @@ class AwsDynamoClientFactory extends ConfigurableService
             if (! $this->hasOption(\common_persistence_KeyLargeValuePersistence::VALUE_MAX_WIDTH)) {
                 $this->setOption(\common_persistence_KeyLargeValuePersistence::VALUE_MAX_WIDTH, self::MAX_WIDTH_VALUE);
             }
-            return new \common_persistence_AdvKeyLargeValuePersistence($this->getOptions(), $driver);
+            return new \common_persistence_AdvKeyLargeValuePersistence($driver, $this->getOptions());
         } else {
-            return new \common_persistence_AdvKeyValuePersistence($this->getOptions(), $driver);
+            return new \common_persistence_AdvKeyValuePersistence($driver, $this->getOptions());
         }
     }
 


### PR DESCRIPTION
Update dependencies fo fixing:

https://oat-sa.atlassian.net/browse/AUT-4490

```2026-03-09 10:17:58 [ERROR] [tao] 'php error(1) in /var/www/html/tao/generis/common/persistence/class.Persistence.php@64: Uncaught TypeError: common_persistence_Persistence
::__construct(): Argument #1 ($driver) must be of type common_persistence_driver, array given, called in /var/www/html/tao/vendor/oat-sa/lib-generis-aws/src/awsDynamoDb/Aws
DynamoClientFactory.php on line 131 and defined in /var/www/html/tao/generis/common/persistence/class.Persistence.php:64
Stack trace:
#0 /var/www/html/tao/vendor/oat-sa/lib-generis-aws/src/awsDynamoDb/AwsDynamoClientFactory.php(131): common_persistence_Persistence->__construct(Array, Object(oat\awsTools\a
wsDynamoDb\AwsDynamoDbDriver))```