### PR TITLE
fix: scope cloudfront keys by delivery compilation id

### DIFF
--- a/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
+++ b/src/QtiItems/QtiItemAssetCloudFrontReplacer.php
@@ -59,7 +59,11 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
      *
      * @throws \common_Exception
      */
-    public function replace(PackedAsset $packetAsset, string $itemId): PackedAsset
+    public function replace(
+        PackedAsset $packetAsset,
+        string $itemId,
+        string $deliveryCompilationId = ''
+    ): PackedAsset
     {
         $filename = $this->getFilenameFormPacket($packetAsset);
 
@@ -79,7 +83,7 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
             $this->getOption(self::OPTION_PREFIX)
         );
 
-        $path = $this->buildPath($itemId);
+        $path = $this->buildPath($itemId, $deliveryCompilationId);
 
         $s3Adapter->writeStream($path . $filename, $this->getResourceFromPacket($packetAsset), $config);
         $path = $this->getOption(self::OPTION_HOST) . DIRECTORY_SEPARATOR . $path . $filename;
@@ -91,9 +95,25 @@ class QtiItemAssetCloudFrontReplacer extends ConfigurableService implements QtiI
     /**
      * Build a final path for an asset
      */
-    private function buildPath(string $itemId): string
+    private function buildPath(string $itemId, string $deliveryCompilationId = ''): string
     {
-        return 'items' . DIRECTORY_SEPARATOR . $itemId . DIRECTORY_SEPARATOR . 'assets' . DIRECTORY_SEPARATOR ;
+        $path = 'items'
+            . DIRECTORY_SEPARATOR
+            . $itemId
+            . DIRECTORY_SEPARATOR
+            . 'assets'
+            . DIRECTORY_SEPARATOR;
+
+        if ($deliveryCompilationId !== '') {
+            $path .= $this->buildDeliveryCompilationSegment($deliveryCompilationId) . DIRECTORY_SEPARATOR;
+        }
+
+        return $path;
+    }
+
+    private function buildDeliveryCompilationSegment(string $deliveryCompilationId): string
+    {
+        return 'dc-' . hash('sha256', $deliveryCompilationId);
     }
 
     /**

--- a/test/unit/QtiItemAssetCloudFrontReplacerTest.php
+++ b/test/unit/QtiItemAssetCloudFrontReplacerTest.php
@@ -183,6 +183,79 @@ class QtiItemAssetCloudFrontReplacerTest extends TestCase
         $this->assertSame('host/items/i12345qwerty/assets/image-link', $packedAssets['image-src']->getReplacedBy());
     }
 
+    public function testReplaceAssetsWithDeliveryCompilationId(): void
+    {
+        $this->item
+            ->method('getComposingElements')
+            ->willReturn([
+                (new ElementMock())->setComposingElements([
+                    $this->createConfiguredMock(XInclude::class, ['attr' => 'stimulus-href'])
+                ]),
+                (new ElementMock())->setComposingElements([
+                    $this->createConfiguredMock(Img::class, ['attr' => 'image-src'])
+                ])
+            ]);
+        $this->item->method('getIdentifier')->willReturn('i12345qwerty');
+
+        $this->resolver->expects($this->exactly(2))
+            ->method('resolve')
+            ->willReturnOnConsecutiveCalls(
+                new MediaAsset(
+                    $this->createConfiguredMock(
+                        MediaBrowser::class,
+                        [
+                            'getFileInfo' => ['link' => 'stimulus-link'],
+                            'getBaseName' => 'stimulus-link'
+                        ]
+                    ),
+                    'stimulus-fixture'
+                ),
+                new MediaAsset(
+                    $this->createConfiguredMock(
+                        MediaBrowser::class,
+                        [
+                            'getFileInfo' => ['link' => 'image-link'],
+                            'getBaseName' => 'image-link',
+                            'getFileStream' => $this->createConfiguredMock(
+                                Stream::class,
+                                [
+                                    'detach' => true
+                                ]
+                            )
+                        ]
+                    ),
+                    'image-fixture'
+                )
+            );
+
+        $this->directory
+            ->method('getFile')
+            ->willReturn(
+                $this->createConfiguredMock(File::class, ['write' => true])
+            );
+
+        $this->blackListService->method('isBlacklisted')->willReturn(false);
+
+        $this->awsClient->method('getS3Client')->willReturn($this->createMock(S3Client::class));
+
+        $packedAssets = $this->subject->extractAndCopyAssetFiles(
+            $this->item,
+            $this->directory,
+            $this->resolver,
+            'delivery-compilation-id'
+        );
+
+        $deliveryCompilationSegment = 'dc-' . hash('sha256', 'delivery-compilation-id');
+
+        $this->assertSame(
+            sprintf(
+                'host/items/i12345qwerty/assets/%s/image-link',
+                $deliveryCompilationSegment
+            ),
+            $packedAssets['image-src']->getReplacedBy()
+        );
+    }
+
     private function getFilenameWithoutPrefix(string $filename): string
     {
         $delimiter = '_';


### PR DESCRIPTION
## Summary

- include publish-specific segment in CloudFront asset key path
- hash `deliveryCompilationId` into a stable URL-safe segment: `dc-<sha256>`
- add unit coverage for replacement with delivery compilation id

## Problem

CloudFront/S3 asset keys could be reused across publishes, which allowed later publishes to overwrite earlier delivery assets.

## Validation


https://github.com/user-attachments/assets/147d33cd-2b97-4a01-a03a-4e1d7b58fc26


- `docker exec nextgen_tao vendor/bin/phpunit --verbose --testdox vendor/oat-sa/lib-generis-aws/test/unit/QtiItemAssetCloudFrontReplacerTest.php`

## Notes

- key format keeps backward compatibility when `deliveryCompilationId` is empty
- paired with taoQtiItem compiler/replacer propagation changes from the same ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced CloudFront asset path generation to include delivery-specific identifiers. Asset paths now incorporate unique segments derived from delivery compilation data, providing improved organization and tracking capabilities for compiled assets across different delivery contexts.

* **Tests**
  * Added unit tests to validate asset path generation and replacement functionality with new delivery compilation identifier parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/lib-generis-aws/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->